### PR TITLE
Alpine and sphinx upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.9
+FROM alpine:3.17.2
 LABEL maintainer="OSC"
 
 # Set language to avoid bugs that sometimes appear

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-sphinx==2.4.5
+sphinx==7.1.2
 sphinx-rtd-theme==0.4.3
 sphinxcontrib-plantuml==0.15
 sphinxcontrib-httpdomain==1.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@ sphinx==7.1.2
 sphinx-rtd-theme==0.4.3
 sphinxcontrib-plantuml==0.15
 sphinxcontrib-httpdomain==1.7.0
-docutils==0.14
-sphinx-tabs==3.3.1
+docutils==0.20


### PR DESCRIPTION
This PR removes some hard coded `requirements` as the build finally worked better when i stopped trying to control those and let `pip` do the job instead. 

I was having issues getting the build to work with the right `ruby` versions, so the jump in the alpine version was largely because it solved all of them without me having to keep adding things in the `DOCKERFILE` which was getting tedious and time consuming.